### PR TITLE
Don't copy source code after build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --update --no-cache openssl ca-certificates
 
 WORKDIR "${CWD}"
 
-COPY Pipfile* "${CWD}/"
+COPY . "${CWD}/"
 
 # `g++` is required for building `gevent` but all build dependencies are
 # later removed again to reduce the layer size.
@@ -34,7 +34,5 @@ RUN set -x \
     && pipenv install --system ${PIPENV_FLAGS} \
     && rm -rf /root/.cache/pip \
     && apk del .build-deps
-
-COPY . "${CWD}/"
 
 RUN chown -R "${APP_USER}:${APP_USER}" "${CWD}"


### PR DESCRIPTION
This fixes a bug in the original Dockerfile build - see [the cookiecutter PR for details](https://github.com/DD-DeCaF/cookiecutter-flask-microservice/pull/35)