### PR TITLE
Experiment data

### DIFF
--- a/src/warehouse/schemas.py
+++ b/src/warehouse/schemas.py
@@ -144,23 +144,29 @@ class GrowthRate(Schema):
     uncertainty = fields.Float(required=True)
 
 
-class ConditionData(Schema):
-    class NestedMedium(Medium):
-        compounds = fields.Nested(MediumCompound, many=True, required=True)
+# Schemas below include full relation objects across foreign keys in the models.
 
-    class NestedSample(Sample):
-        fluxomics = fields.Nested(Fluxomics, many=True, required=True)
-        metabolomics = fields.Nested(Metabolomics, many=True, required=True)
-        proteomics = fields.Nested(Proteomics, many=True, required=True)
-        uptake_secretion_rates = fields.Nested(
-            UptakeSecretionRates, many=True, required=True
-        )
-        molar_yields = fields.Nested(MolarYields, many=True, required=True)
-        growth_rate = fields.Nested(GrowthRate, required=True)
 
-    id = fields.Integer(required=True)
-    experiment = fields.Nested(Experiment, required=True)
+class SampleData(Schema):
+    fluxomics = fields.Nested(Fluxomics, many=True, required=True)
+    metabolomics = fields.Nested(Metabolomics, many=True, required=True)
+    proteomics = fields.Nested(Proteomics, many=True, required=True)
+    uptake_secretion_rates = fields.Nested(
+        UptakeSecretionRates, many=True, required=True
+    )
+    molar_yields = fields.Nested(MolarYields, many=True, required=True)
+    growth_rate = fields.Nested(GrowthRate, required=True)
+
+
+class MediumData(Medium):
+    compounds = fields.Nested(MediumCompound, many=True, required=True)
+
+
+class ConditionData(Condition):
     strain = fields.Nested(Strain, required=True)
-    medium = fields.Nested(NestedMedium, required=True)
-    name = fields.String(required=True)
-    samples = fields.Nested(NestedSample, many=True, required=True)
+    medium = fields.Nested(MediumData, required=True)
+    samples = fields.Nested(SampleData, many=True, required=True)
+
+
+class ExperimentData(Experiment):
+    conditions = fields.Nested(ConditionData, many=True, required=True)

--- a/src/warehouse/schemas.py
+++ b/src/warehouse/schemas.py
@@ -147,7 +147,7 @@ class GrowthRate(Schema):
 # Schemas below include full relation objects across foreign keys in the models.
 
 
-class SampleData(Schema):
+class SampleData(Sample):
     fluxomics = fields.Nested(Fluxomics, many=True, required=True)
     metabolomics = fields.Nested(Metabolomics, many=True, required=True)
     proteomics = fields.Nested(Proteomics, many=True, required=True)

--- a/tests/test_integration/test_endpoints_crud.py
+++ b/tests/test_integration/test_endpoints_crud.py
@@ -189,6 +189,14 @@ def test_delete_experiment(client, tokens, session, data_fixtures):
     )
 
 
+def test_get_experiment_data(client, tokens, session, data_fixtures):
+    response = client.get(
+        f"/experiments/{data_fixtures['experiment'].id}/data",
+        headers={"Authorization": f"Bearer {tokens['read']}"},
+    )
+    assert response.status_code == 200
+
+
 def test_post_proteomics(client, tokens, session, data_fixtures):
     proteomics_request = {
         "sample_id": data_fixtures["sample"].id,


### PR DESCRIPTION
The new resource allows clients to request all related data for a single experiment. This is needed for our [edit experiment feature](https://app.zenhub.com/workspaces/bioviz-scrum-5d22fe4139b1324e0011234c/issues/dd-decaf/scrum/1137) in Caffeine.